### PR TITLE
Expanded discovery to return assembly details

### DIFF
--- a/src/BitDeploy.Deployer.Tests/Features/Discovery/ConfiguredInstallationManifestTests.cs
+++ b/src/BitDeploy.Deployer.Tests/Features/Discovery/ConfiguredInstallationManifestTests.cs
@@ -14,12 +14,14 @@ namespace BitDeploy.Deployer.Tests.Features.Discovery
             var config = new InstallationConfiguration("path");
             var installer = new TestInstaller();
             const string path = "path";
+            var discoveredDetails = new AssemblyDetails(path, "binary.dll", typeof (TestInstaller));
 
-            var dto = new ConfiguredInstallationManifest(config, installer, path);
+            var dto = new ConfiguredInstallationManifest(config, installer, path, discoveredDetails);
 
             Assert.That(dto.InstallationConfiguration, Is.EqualTo(config));
             Assert.That(dto.SourceInstaller, Is.EqualTo(installer));
             Assert.That(dto.Path, Is.EqualTo(path));
+            Assert.That(dto.DiscoveredDetails, Is.EqualTo(discoveredDetails));
         }
     }
 }

--- a/src/BitDeploy.Deployer.Tests/Features/Discovery/PathScannerTests.cs
+++ b/src/BitDeploy.Deployer.Tests/Features/Discovery/PathScannerTests.cs
@@ -72,7 +72,7 @@ namespace BitDeploy.Deployer.Tests.Features.Discovery
 
             Assert.That(manifest.InstallationConfiguration, Is.Not.Null);
             Assert.That(manifest.Path, Is.EqualTo(_siteScanPath));
-            Assert.That(manifest.SourceInstaller, Is.Not.Null);
+            Assert.That(manifest.SourceInstaller, Is.InstanceOf<ISiteInstaller>());
         }
     }
 }

--- a/src/BitDeploy.Deployer.Tests/Features/Discovery/PathScannerTests.cs
+++ b/src/BitDeploy.Deployer.Tests/Features/Discovery/PathScannerTests.cs
@@ -62,6 +62,19 @@ namespace BitDeploy.Deployer.Tests.Features.Discovery
         }
 
         [Test]
+        public void FindFirstAvailableInstaller_MultipleAssembliesFound_ReturnsManifestForFirstOne()
+        {
+            var expectedAssembly = new AssemblyDetails("c:\\path", "expect.this.dll", typeof (TestInstaller));
+            var shouldNotCreate = new AssemblyDetails("c:\\path", "do.not.expect.this.dll", typeof (TestInstaller));
+            _discoverer.Setup(x => x.FindAssemblies(It.IsAny<string>())).Returns(new List<AssemblyDetails> { expectedAssembly, shouldNotCreate });
+            _loader.Setup(x => x.Load("c:\\path\\expect.this.dll")).Returns(Assembly.GetAssembly(typeof(PathScannerTests)));
+
+            var manifest = _pathScanner.FindFirstAvailableInstaller();
+
+            Assert.That(manifest.DiscoveredDetails, Is.EqualTo(expectedAssembly));
+        }
+
+        [Test]
         public void FindFirstAvailableInstaller_AssemblyFound_ReturnsConfiguredManifestForAssembly()
         {
             var foundAssembly = new AssemblyDetails("c:\\path", "binary.dll", typeof(TestInstaller));

--- a/src/BitDeploy.Deployer/Features/Discovery/ConfiguredInstallationManifest.cs
+++ b/src/BitDeploy.Deployer/Features/Discovery/ConfiguredInstallationManifest.cs
@@ -7,12 +7,14 @@ namespace BitDeploy.Deployer.Features.Discovery
         public InstallationConfiguration InstallationConfiguration { get; set; }
         public ISiteInstaller SourceInstaller { get; set; }
         public string Path { get; set; }
+        public AssemblyDetails DiscoveredDetails { get; set; }
 
-        public ConfiguredInstallationManifest(InstallationConfiguration installationConfiguration, ISiteInstaller sourceInstaller, string path)
+        public ConfiguredInstallationManifest(InstallationConfiguration installationConfiguration, ISiteInstaller sourceInstaller, string path, AssemblyDetails discoveredDetails)
         {
             InstallationConfiguration = installationConfiguration;
             SourceInstaller = sourceInstaller;
             Path = path;
+            DiscoveredDetails = discoveredDetails;
         }
     }
 }

--- a/src/BitDeploy.Deployer/Features/Discovery/NoInstallationFound.cs
+++ b/src/BitDeploy.Deployer/Features/Discovery/NoInstallationFound.cs
@@ -3,7 +3,7 @@
     public class NoInstallationFound : ConfiguredInstallationManifest
     {
         public NoInstallationFound() 
-            : base(null, null, null)
+            : base(null, null, null, null)
         {
         }
     }

--- a/src/BitDeploy.Deployer/Features/Discovery/PathScanner.cs
+++ b/src/BitDeploy.Deployer/Features/Discovery/PathScanner.cs
@@ -39,7 +39,7 @@ namespace BitDeploy.Deployer.Features.Discovery
             var siteInstaller = assemblyWithSiteInstaller.CreateInstance(firstInstaller.InstallerType.FullName, true);
             var configuration = new InstallationConfiguration(_scanSitePath);
 
-            return new ConfiguredInstallationManifest(configuration, (ISiteInstaller)siteInstaller, _scanSitePath);
+            return new ConfiguredInstallationManifest(configuration, (ISiteInstaller)siteInstaller, _scanSitePath, firstInstaller);
         }
     }
 }


### PR DESCRIPTION
Discovery now returns all the discovered information it finds, vital in testing correctness, and I expect, vital to debug logging during installation.

Test now ensures that "First matching ISiteInstaller is returned".
